### PR TITLE
provide package

### DIFF
--- a/forge-search.el
+++ b/forge-search.el
@@ -136,3 +136,5 @@ issues and pull requests (with their replies)"
 "View the issue/pull request under point with the browser"
   (interactive)
   (forge--search-do-at-point 'forge-browse-issue 'forge-browse-pullreq))
+
+(provide 'forge-search)


### PR DESCRIPTION
Add `(provide 'forge-search)` at the end of the file so that the package can be installed directly from the repo with `straight`/`elpaca`.